### PR TITLE
Potential fix for code scanning alert no. 2: Syntax error

### DIFF
--- a/assets/code/TypeScript/WebRTC.tsx
+++ b/assets/code/TypeScript/WebRTC.tsx
@@ -17,7 +17,7 @@ export async function initWebRTC() {
     console.log("[WebRTC/info] поток инициализирован");
     return stream;
   } catch (err) {
-    console.error("[WebRTC/ERR] ошибка при инициализации:, err);
+    console.error("[WebRTC/ERR] ошибка при инициализации:", err);
     return null;
   }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/dvytvs/Ruscord-net-Linux/security/code-scanning/2](https://github.com/dvytvs/Ruscord-net-Linux/security/code-scanning/2)

The syntax error on line 20 should be fixed by properly closing the string literal and correctly passing the `err` object as a second argument to `console.error`. The corrected line should look like:
```ts
console.error("[WebRTC/ERR] ошибка при инициализации:", err);
```
This involves:
- Adding the missing closing double quote `"` for the string.
- Adding a comma to separate the string from the `err` variable.
- Adding the missing closing parenthesis.

No further code edits are needed. The fix is localized to line 20 in `assets/code/TypeScript/WebRTC.tsx`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
