### PR TITLE
Potential fix for code scanning alert no. 3: Unused variable, import, function or class

### DIFF
--- a/assets/code/TypeScript/WebRTC-preload.tsx
+++ b/assets/code/TypeScript/WebRTC-preload.tsx
@@ -1,4 +1,3 @@
-const { contextBridge } = require("electron");
 const { initWebRTC } = require("./WebRTC.tsx");
 
 window.addEventListener("DOMContentLoaded", () => {


### PR DESCRIPTION
Potential fix for [https://github.com/dvytvs/Ruscord-net-Linux/security/code-scanning/3](https://github.com/dvytvs/Ruscord-net-Linux/security/code-scanning/3)

To fix the problem, we should remove the unused variable `contextBridge` from line 1 of the file `assets/code/TypeScript/WebRTC-preload.tsx`. This simply involves deleting that line, as none of the other code relies on this variable, and removing it does not impact functionality. No further changes or imports are needed given the scope of the snippet.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
